### PR TITLE
Registry fix + log improvements

### DIFF
--- a/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
+++ b/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
@@ -1,5 +1,6 @@
 package nl.erwinvaneyk.communication;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.erwinvaneyk.communication.exceptions.CommunicationException;
 import nl.erwinvaneyk.communication.rmi.RMISocket;
 import nl.erwinvaneyk.core.Node;
@@ -11,6 +12,7 @@ import java.util.Set;
 import static java.util.stream.Collectors.toSet;
 
 // TODO: separate from rmi
+@Slf4j
 public class ConnectorImpl implements Connector {
     private final Node me;
 
@@ -65,6 +67,10 @@ public class ConnectorImpl implements Connector {
 
 	@Override
 	public void log(Message message) {
-		broadcast(message, LogNode.NODE_TYPE);
+		if(me.getState().getConnectedNodes().stream().anyMatch(node -> node.getType().equals(LogNode.NODE_TYPE))) {
+			broadcast(message, LogNode.NODE_TYPE);
+		} else {
+			log.debug("No logger: " + message);
+		}
 	}
 }

--- a/src/main/java/nl/erwinvaneyk/communication/rmi/RMIRegistry.java
+++ b/src/main/java/nl/erwinvaneyk/communication/rmi/RMIRegistry.java
@@ -11,6 +11,7 @@ import java.rmi.server.UnicastRemoteObject;
 import java.util.Optional;
 
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nl.erwinvaneyk.communication.MessageHandler;
 import nl.erwinvaneyk.communication.Server;
 import nl.erwinvaneyk.communication.exceptions.PortAlreadyInUseException;
@@ -48,9 +49,9 @@ public class RMIRegistry implements Server {
 			try {
 				// Fix race condition, when previous registry is still in shutdown.
 				Thread.sleep(500);
-				return start(port);
+				registry = LocateRegistry.createRegistry(port);
 			}
-			catch (InterruptedException e1) {
+			catch (InterruptedException | RemoteException e1) {
 				throw new PortAlreadyInUseException("Failed to start RMI-registry (server).", e);
 			}
 		}

--- a/src/main/java/nl/erwinvaneyk/core/logging/LogMessage.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/LogMessage.java
@@ -1,5 +1,6 @@
 package nl.erwinvaneyk.core.logging;
 
+import ch.qos.logback.classic.Level;
 import lombok.Getter;
 import nl.erwinvaneyk.communication.BasicMessage;
 import nl.erwinvaneyk.core.NodeAddress;
@@ -9,9 +10,19 @@ public class LogMessage extends BasicMessage{
 	@Getter
 	private final String log;
 
+	@Getter
+	private final Level level;
+
 	public LogMessage(String log, NodeAddress origin) {
 		super(LogNode.CONTEXT, origin);
 		this.log = log;
+		this.level = Level.DEBUG;
+	}
+
+	public LogMessage(String log, Level level, NodeAddress origin) {
+		super(LogNode.CONTEXT, origin);
+		this.log = log;
+		this.level = level;
 	}
 
 	@Override

--- a/src/test/java/nl/erwinvaneyk/communication/rmi/RMIRegistryTest.java
+++ b/src/test/java/nl/erwinvaneyk/communication/rmi/RMIRegistryTest.java
@@ -1,5 +1,6 @@
 package nl.erwinvaneyk.communication.rmi;
 
+import static junit.framework.TestCase.fail;
 import static org.mockito.Mockito.mock;
 
 import nl.erwinvaneyk.communication.MessageHandler;
@@ -42,5 +43,18 @@ public class RMIRegistryTest {
 		new RMIRegistry()
 				.start(1818)
 				.shutdown();
+	}
+
+	@Test
+	public void startingRegistryOnUnavailablePort() throws PortAlreadyInUseException {
+		Server registry = new RMIRegistry().start(1818);
+		try {
+			new RMIRegistry().start(1818);
+			fail();
+		} catch (Exception e) {
+			System.out.println(e.getMessage());
+		} finally {
+			registry.shutdown();
+		}
 	}
 }


### PR DESCRIPTION
Changelog:
- Fixes recursion-bug in the creation of registries. When a port is already in use the system would keep attempting to create a new registry.
- Adds log-level to LogMessage. Not used now, but this is a useful feature in the future
- Connector prints logs if there are no connected LogNodes to the cluster.

*Will be released on the following MINOR version*