### PR TITLE
NodeState is being used i.s.o. Node in ConnectorImpl

### DIFF
--- a/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
+++ b/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
@@ -3,8 +3,8 @@ package nl.erwinvaneyk.communication;
 import lombok.extern.slf4j.Slf4j;
 import nl.erwinvaneyk.communication.exceptions.CommunicationException;
 import nl.erwinvaneyk.communication.rmi.RMISocket;
-import nl.erwinvaneyk.core.Node;
 import nl.erwinvaneyk.core.NodeAddress;
+import nl.erwinvaneyk.core.NodeState;
 import nl.erwinvaneyk.core.logging.LogNode;
 
 import java.util.Set;
@@ -14,9 +14,9 @@ import static java.util.stream.Collectors.toSet;
 // TODO: separate from rmi
 @Slf4j
 public class ConnectorImpl implements Connector {
-    private final Node me;
+    private final NodeState me;
 
-    public ConnectorImpl(Node me) {
+    public ConnectorImpl(NodeState me) {
         this.me = me;
     }
 
@@ -34,13 +34,13 @@ public class ConnectorImpl implements Connector {
 
     @Override
     public Set<NodeAddress> broadcast(Message message) {
-        Set<NodeAddress> nodes = me.getState().getConnectedNodes();
+        Set<NodeAddress> nodes = me.getConnectedNodes();
 
         return broadcast(message, nodes);
     }
 
     public Set<NodeAddress> broadcast(Message message, String identifierFilter) {
-        Set<NodeAddress> nodes = me.getState().getConnectedNodes()
+        Set<NodeAddress> nodes = me.getConnectedNodes()
                 .stream()
                 .filter(n -> n.getIdentifier().matches("(.*)" + identifierFilter + "(.*)")).collect(toSet());
 
@@ -57,7 +57,7 @@ public class ConnectorImpl implements Connector {
         });
 
         try {
-            sendMessage(message, me.getState().getAddress());
+            sendMessage(message, me.getAddress());
         } catch (CommunicationException e) {
             e.printStackTrace();
         }
@@ -67,7 +67,7 @@ public class ConnectorImpl implements Connector {
 
 	@Override
 	public void log(Message message) {
-		if(me.getState().getConnectedNodes().stream().anyMatch(node -> node.getType().equals(LogNode.NODE_TYPE))) {
+		if(me.getConnectedNodes().stream().anyMatch(node -> LogNode.NODE_TYPE.equals(node.getType()))) {
 			broadcast(message, LogNode.NODE_TYPE);
 		} else {
 			log.debug("No logger: " + message);

--- a/src/main/java/nl/erwinvaneyk/core/NodeImpl.java
+++ b/src/main/java/nl/erwinvaneyk/core/NodeImpl.java
@@ -3,16 +3,12 @@ package nl.erwinvaneyk.core;
 import java.rmi.RemoteException;
 
 import lombok.Data;
-import nl.erwinvaneyk.communication.BasicMessage;
 import nl.erwinvaneyk.communication.Connector;
 import nl.erwinvaneyk.communication.ConnectorImpl;
-import nl.erwinvaneyk.communication.Message;
 import nl.erwinvaneyk.communication.exceptions.CommunicationException;
 import nl.erwinvaneyk.communication.rmi.NoBufferMessageHandler;
 import nl.erwinvaneyk.communication.Server;
 import nl.erwinvaneyk.communication.MessageHandler;
-import nl.erwinvaneyk.communication.rmi.RMIRegistry;
-import nl.erwinvaneyk.communication.rmi.RMISocket;
 import nl.erwinvaneyk.communication.handlers.NodeConnectHandler;
 import nl.erwinvaneyk.communication.handlers.NodeInitHandler;
 
@@ -30,7 +26,7 @@ public class NodeImpl implements Node {
 	protected NodeImpl(NodeAddress address, Server registry, String clusterId) throws CommunicationException {
 		this.state = new NodeState(address, clusterId);
 		this.registry = registry;
-		this.connector = new ConnectorImpl(this);
+		this.connector = new ConnectorImpl(this.getState());
 		try {
 			messageHandler = new NoBufferMessageHandler(address);
 			messageHandler.bind(new NodeInitHandler(connector, state));

--- a/src/test/java/nl/erwinvaneyk/core/LogNode/LogNodeTest.java
+++ b/src/test/java/nl/erwinvaneyk/core/LogNode/LogNodeTest.java
@@ -53,7 +53,7 @@ public class LogNodeTest {
 		logNode2.setLogger(message -> lastLogMessage2 = message);
 		// Log and check
 		Message message = new LogMessage("Test message", null);
-		new ConnectorImpl(node1).log(message);
+		new ConnectorImpl(node1.getState()).log(message);
 		assertNotNull(lastLogMessage1);
 		assertNotNull(lastLogMessage2);
 		assertEquals(lastLogMessage2, lastLogMessage1);


### PR DESCRIPTION
`ConnectorImpl` only used the `NodeState` anyways, no need to pass the complete `Node`.