### PR TITLE
Fixed bug in ConnectorImpl

### DIFF
--- a/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
+++ b/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
@@ -42,12 +42,14 @@ public class ConnectorImpl implements Connector {
     }
 
     public Set<NodeAddress> broadcast(Message message, String identifierFilter) {
-        Set<NodeAddress> nodes = new HashSet<>(me.getConnectedNodes());
-        nodes.add(me.getAddress());
+        String regex = "(.*)" + identifierFilter + "(.*)";
 
-        nodes = nodes.stream()
-                    .filter(n -> n.getIdentifier().matches("(.*)" + identifierFilter + "(.*)"))
+        Set<NodeAddress> nodes = me.getConnectedNodes().stream()
+                    .filter(n -> n.getIdentifier().matches(regex))
                     .collect(toSet());
+
+        if(me.getAddress().getIdentifier().matches(regex))
+            nodes.add(me.getAddress());
 
         return broadcast(message, nodes);
     }

--- a/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
+++ b/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
@@ -7,6 +7,7 @@ import nl.erwinvaneyk.core.NodeAddress;
 import nl.erwinvaneyk.core.NodeState;
 import nl.erwinvaneyk.core.logging.LogNode;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -34,15 +35,19 @@ public class ConnectorImpl implements Connector {
 
     @Override
     public Set<NodeAddress> broadcast(Message message) {
-        Set<NodeAddress> nodes = me.getConnectedNodes();
+        Set<NodeAddress> nodes = new HashSet<>(me.getConnectedNodes());
+        nodes.add(me.getAddress());
 
         return broadcast(message, nodes);
     }
 
     public Set<NodeAddress> broadcast(Message message, String identifierFilter) {
-        Set<NodeAddress> nodes = me.getConnectedNodes()
-                .stream()
-                .filter(n -> n.getIdentifier().matches("(.*)" + identifierFilter + "(.*)")).collect(toSet());
+        Set<NodeAddress> nodes = new HashSet<>(me.getConnectedNodes());
+        nodes.add(me.getAddress());
+
+        nodes = nodes.stream()
+                    .filter(n -> n.getIdentifier().matches("(.*)" + identifierFilter + "(.*)"))
+                    .collect(toSet());
 
         return broadcast(message, nodes);
     }
@@ -55,12 +60,6 @@ public class ConnectorImpl implements Connector {
                 e.printStackTrace();
             }
         });
-
-        try {
-            sendMessage(message, me.getAddress());
-        } catch (CommunicationException e) {
-            e.printStackTrace();
-        }
 
         return nodes;
     }

--- a/src/main/java/nl/erwinvaneyk/core/Node.java
+++ b/src/main/java/nl/erwinvaneyk/core/Node.java
@@ -1,5 +1,6 @@
 package nl.erwinvaneyk.core;
 
+import nl.erwinvaneyk.communication.Connector;
 import nl.erwinvaneyk.communication.MessageHandler;
 
 public interface Node {
@@ -9,6 +10,8 @@ public interface Node {
 	String getType();
 
 	void disconnect();
+
+	Connector getConnector();
 
 	MessageHandler getMessageHandler();
 }

--- a/src/test/java/nl/erwinvaneyk/communication/ConnectorImplTest.java
+++ b/src/test/java/nl/erwinvaneyk/communication/ConnectorImplTest.java
@@ -1,4 +1,79 @@
 package nl.erwinvaneyk.communication;
 
+import nl.erwinvaneyk.communication.exceptions.CommunicationException;
+import nl.erwinvaneyk.core.ClusterFactory;
+import nl.erwinvaneyk.core.Node;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.rmi.RemoteException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 // TODO: needs cluster-joins to be able to test
-public class ConnectorImplTest {}
+public class ConnectorImplTest {
+    private boolean receivedOwnMessage = false;
+
+    @Before
+    public void reset() {
+        receivedOwnMessage = false;
+    }
+
+    @Test
+    public void connectorBroadcastSingleProcessNoFilter() throws RemoteException {
+        // Setup cluster
+        Node node1 = ClusterFactory.getBasicFactory().startCluster(1819, "test-cluster");
+        node1.getMessageHandler().bind(new MessageReceivedHandler() {
+            @Override
+            public Message onMessage(Message message) throws CommunicationException {
+                ConnectorImplTest.this.receivedOwnMessage = true;
+                return null;
+            }
+
+            @Override
+            public String getContext() {
+                return "test-cluster";
+            }
+        });
+
+        ConnectorImpl connector = (ConnectorImpl) node1.getConnector();
+
+        Message message = new BasicMessage("test-cluster", node1.getState().getAddress());
+        connector.broadcast(message);
+
+        assertTrue(receivedOwnMessage);
+
+        // Shutdown
+        node1.disconnect();
+    }
+
+
+    @Test
+    public void connectorBroadcastSingleProcessWithFilter() throws RemoteException {
+        // Setup cluster
+        Node node1 = ClusterFactory.getBasicFactory().startCluster(1820, "test-cluster");
+        node1.getMessageHandler().bind(new MessageReceivedHandler() {
+            @Override
+            public Message onMessage(Message message) throws CommunicationException {
+                ConnectorImplTest.this.receivedOwnMessage = true;
+                return null;
+            }
+
+            @Override
+            public String getContext() {
+                return "test-cluster";
+            }
+        });
+
+        ConnectorImpl connector = (ConnectorImpl) node1.getConnector();
+
+        Message message = new BasicMessage("test-cluster", node1.getState().getAddress());
+        connector.broadcast(message, "randomId");
+
+        assertFalse(receivedOwnMessage);
+
+        // Shutdown
+        node1.disconnect();
+    }
+}


### PR DESCRIPTION
You should only receive your own message back after a broadcast when your identifier satisfies the filter.
Added tests to ensure that this is working properly now.