### PR TITLE
Add performance logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/erwinvaneyk/distributedrmi.svg)](https://travis-ci.org/erwinvaneyk/distributedrmi)
 
-Installation:
+### Installation:
 To use it in your project add the following to your `pom.xml`:
 
 ```xml
@@ -24,7 +24,7 @@ To use it in your project add the following to your `pom.xml`:
 </dependency>
 ```
 
-Example:
+### Example:
 ```java
 // Setup cluster
 ClusterFactory cf = ClusterFactory.getBasicFactory();
@@ -47,3 +47,16 @@ node2.disconnect();
 logNode1.disconnect();
 ```
 Note: In this case the nodes are still running from a common thread.
+
+### InfluxDB
+This project provides advanced performance-logging capabilities. By default InfluxDB is included. To enable it, make sure that a InfluxDB instance is running on your machine.
+
+The easiest way to do this is to use the preconfigured docker-image
+```bash
+# run influxdb
+docker run -d -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 --name="influxdb-rmi" tutum/influxdb
+
+# run grafana
+docker run -d -p 3000:3000 --name="grafana-rmi" grafana/grafana
+
+```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ logNode1.disconnect();
 Note: In this case the nodes are still running from a common thread.
 
 ### InfluxDB
-This project provides advanced performance-logging capabilities. By default InfluxDB is included. To enable it, make sure that a InfluxDB instance is running on your machine.
+This project provides advanced performance-logging capabilities. By default InfluxDB is included. To enable it, make sure that an InfluxDB-instance is running on your machine.
 
 The easiest way to do this is to use the preconfigured docker-image
 ```bash

--- a/src/main/java/nl/erwinvaneyk/communication/BasicMessage.java
+++ b/src/main/java/nl/erwinvaneyk/communication/BasicMessage.java
@@ -3,6 +3,7 @@ package nl.erwinvaneyk.communication;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,23 +15,28 @@ public class BasicMessage implements Message {
 
 	private final String context;
 	private final NodeAddress origin;
-	private final Date timestampSend;
-	private Date timestampReceived;
+	private final long timestampSend;
+	private long timestampReceived;
 	private final HashMap<String, Serializable> contents = new HashMap<>();
 
 	public BasicMessage(String context, NodeAddress origin) {
 		this.context = context;
 		this.origin = origin;
-		this.timestampSend = new Date();
+		this.timestampSend = new Date().getTime();
 	}
 
 	public void setTimestampReceived() {
-		timestampReceived = new Date();
+		timestampReceived = new Date().getTime();
 	}
 
 	@Override
 	public Serializable get(String fieldName) {
 		return contents.get(fieldName);
+	}
+
+	@Override
+	public Map<String, Serializable> getFields() {
+		return contents;
 	}
 
 	@Override

--- a/src/main/java/nl/erwinvaneyk/communication/Message.java
+++ b/src/main/java/nl/erwinvaneyk/communication/Message.java
@@ -2,6 +2,7 @@ package nl.erwinvaneyk.communication;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Map;
 
 import nl.erwinvaneyk.core.NodeAddress;
 
@@ -11,13 +12,15 @@ public interface Message extends Serializable {
 
 	NodeAddress getOrigin();
 
-	Date getTimestampSend();
+	long getTimestampSend();
 
-	Date getTimestampReceived();
+	long getTimestampReceived();
 
 	void setTimestampReceived();
 
 	Serializable get(String fieldName);
+
+	Map<String, Serializable> getFields();
 
 	Serializable getOrThrow(String fieldname);
 

--- a/src/main/java/nl/erwinvaneyk/communication/Message.java
+++ b/src/main/java/nl/erwinvaneyk/communication/Message.java
@@ -1,7 +1,6 @@
 package nl.erwinvaneyk.communication;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.Map;
 
 import nl.erwinvaneyk.core.NodeAddress;

--- a/src/main/java/nl/erwinvaneyk/communication/rmi/NoBufferMessageDistributor.java
+++ b/src/main/java/nl/erwinvaneyk/communication/rmi/NoBufferMessageDistributor.java
@@ -9,18 +9,15 @@ import nl.erwinvaneyk.communication.Message;
 import nl.erwinvaneyk.communication.MessageDistributor;
 import nl.erwinvaneyk.communication.MessageReceivedHandler;
 import nl.erwinvaneyk.communication.exceptions.CommunicationException;
-import nl.erwinvaneyk.core.NodeAddress;
+import nl.erwinvaneyk.core.logging.RawLogger;
 
 // TODO: RMI stuff needs to be split from the messageHandler interface
-public class NoBufferMessageHandler extends UnicastRemoteObject implements MessageDistributor {
+public class NoBufferMessageDistributor extends UnicastRemoteObject implements MessageDistributor {
 
 	private final Map<String, MessageReceivedHandler> handlers = new ConcurrentHashMap<>();
 
-	private final NodeAddress address;
-
-	public NoBufferMessageHandler(NodeAddress address) throws RemoteException {
+	public NoBufferMessageDistributor() throws RemoteException {
 		super();
-		this.address = address;
 	}
 
 	@Override
@@ -31,6 +28,7 @@ public class NoBufferMessageHandler extends UnicastRemoteObject implements Messa
 	@Override
 	public Message onRequestReceived(Message message) throws RemoteException {
 		message.setTimestampReceived();
+		RawLogger.getDefault().log("message", message);
 		MessageReceivedHandler handler = getHandlerFor(message);
 		if(handler != null) {
 			return handler.onMessage(message);

--- a/src/main/java/nl/erwinvaneyk/core/NodeImpl.java
+++ b/src/main/java/nl/erwinvaneyk/core/NodeImpl.java
@@ -4,16 +4,11 @@ import java.rmi.RemoteException;
 
 import lombok.Getter;
 import lombok.ToString;
-import nl.erwinvaneyk.communication.BasicMessageFactory;
-import nl.erwinvaneyk.communication.Connector;
-import nl.erwinvaneyk.communication.ConnectorImpl;
-import nl.erwinvaneyk.communication.MessageDistributor;
-import nl.erwinvaneyk.communication.MessageFactory;
-import nl.erwinvaneyk.communication.Server;
+import nl.erwinvaneyk.communication.*;
 import nl.erwinvaneyk.communication.exceptions.CommunicationException;
 import nl.erwinvaneyk.communication.handlers.NodeConnectHandler;
 import nl.erwinvaneyk.communication.handlers.NodeInitHandler;
-import nl.erwinvaneyk.communication.rmi.NoBufferMessageHandler;
+import nl.erwinvaneyk.communication.rmi.NoBufferMessageDistributor;
 
 @ToString
 public class NodeImpl implements Node {
@@ -37,7 +32,7 @@ public class NodeImpl implements Node {
 		this.connector = new ConnectorImpl(this.getState());
 		this.messageFactory = new BasicMessageFactory(address);
 		try {
-			messageDistributor = new NoBufferMessageHandler(address);
+			messageDistributor = new NoBufferMessageDistributor();
 			messageDistributor.bind(new NodeInitHandler(connector, state));
 			messageDistributor.bind(new NodeConnectHandler(state));
 		}

--- a/src/main/java/nl/erwinvaneyk/core/logging/InfluxLogger.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/InfluxLogger.java
@@ -1,0 +1,115 @@
+package nl.erwinvaneyk.core.logging;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import nl.erwinvaneyk.communication.Message;
+import nl.erwinvaneyk.core.Address;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.Database;
+import org.influxdb.dto.Serie;
+import retrofit.RetrofitError;
+
+@Slf4j
+public class InfluxLogger implements RawLogger {
+
+	public static final String DEFAULT_DATABASE = "distributedrmi";
+	public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
+	public static final String FIELD_ORIGIN = "origin";
+	public static final String FIELD_SUBJECT = "subject";
+	public static final String FIELD_TIMESTAMP_SEND = "timestamp_send";
+	public static final String FIELD_TIMESTAMP_RECEIVED = "timestamp_received";
+
+	private static InfluxLogger influxLogger;
+
+	private final InfluxDB influxDB;
+	private final String database;
+	private boolean available = true;
+
+	/**
+	 *
+	 * @param address default: http://172.17.0.2:8086
+	 * @param username default: root
+	 * @param password default: root
+	 */
+	public InfluxLogger(Address address, String username, String password, String database) {
+		influxDB = InfluxDBFactory.connect(address.toString(), username, password);
+		this.database = database;
+		createDatabaseIfAbsent(database);
+	}
+
+	public static InfluxLogger getInstance() {
+		if(influxLogger == null) {
+			influxLogger =  new InfluxLogger(new Address("localhost",8086), "root", "root", InfluxLogger.DEFAULT_DATABASE);
+			influxLogger.deleteDatabase();
+			influxLogger.createDatabaseIfAbsent(influxLogger.database);
+		}
+		return influxLogger;
+	}
+
+	public void log(@NonNull String subject,@NonNull Map<String,Object> args) {
+		if(!available) {
+			return;
+		}
+		if(args.isEmpty()) {
+			log.warn("Cannot write a serie with no arguments to subject: {}", subject);
+			return;
+		}
+		Serie.Builder builder = new Serie.Builder(subject);
+		String[] columns = args.keySet().toArray(new String[args.size()]);
+		builder.columns(columns);
+		builder.values(args.values().toArray(new Object[args.size()]));
+		Serie serie = builder.build();
+		log.debug("query to influxDB: {}", serie);
+		influxDB.write(database, TIME_UNIT, serie);
+	}
+
+	@Override
+	public void log(Message message) {
+		log(message.getContext(), message);
+	}
+
+	@Override
+	public void log(String subject, Message message) {
+		Map<String, Object> args = new HashMap<>(message.getFields());
+		args.put(FIELD_ORIGIN, message.getOrigin() != null ? message.getOrigin().toString() : "");
+		args.put(FIELD_SUBJECT, subject);
+		args.put(FIELD_TIMESTAMP_RECEIVED, message.getTimestampReceived());
+		args.put(FIELD_TIMESTAMP_SEND, message.getTimestampSend());
+		log(subject, args);
+	}
+
+	@Override
+	public boolean isAvailable() {
+		try {
+			return influxDB.ping() != null;
+		} catch (RetrofitError e) {
+			return false;
+		}
+	}
+
+	void deleteDatabase() {
+		if(available) {
+			influxDB.deleteDatabase(database);
+			log.debug("Deleted InfluxDB database: {}", database);
+		} else {
+			log.warn("Could not delete database '{}'; no connection to InfluxDB");
+		}
+	}
+
+	void createDatabaseIfAbsent(String database) {
+		if(isAvailable()) {
+			if(!influxDB.describeDatabases().stream().map(Database::getName).anyMatch(db -> db.equals(database))) {
+				log.debug("Created InfluxDB database: {} ", database);
+				influxDB.createDatabase(database);
+			}
+		} else {
+			log.warn("Could not connect to InfluxDB, any logs will be ignored!");
+			available = false;
+		}
+	}
+}

--- a/src/main/java/nl/erwinvaneyk/core/logging/Logger.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/Logger.java
@@ -5,4 +5,8 @@ import nl.erwinvaneyk.communication.Message;
 public interface Logger {
 
 	void log(Message message);
+
+	default boolean isAvailable() {
+		return true;
+	}
 }

--- a/src/main/java/nl/erwinvaneyk/core/logging/PrintLogger.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/PrintLogger.java
@@ -8,4 +8,9 @@ public class PrintLogger implements Logger {
 	public void log(Message message) {
 		System.out.println(message.toString());
 	}
+
+	@Override
+	public boolean isAvailable() {
+		return true;
+	}
 }

--- a/src/main/java/nl/erwinvaneyk/core/logging/RawLogger.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/RawLogger.java
@@ -1,0 +1,16 @@
+package nl.erwinvaneyk.core.logging;
+
+import java.util.Map;
+
+import nl.erwinvaneyk.communication.Message;
+
+public interface RawLogger extends Logger {
+
+	void log(String subject, Map<String,Object> args);
+
+	void log(String subject, Message message);
+
+	public static RawLogger getDefault() {
+		return InfluxLogger.getInstance();
+	}
+}

--- a/src/test/java/nl/erwinvaneyk/core/logging/InfluxLoggerTest.java
+++ b/src/test/java/nl/erwinvaneyk/core/logging/InfluxLoggerTest.java
@@ -1,0 +1,57 @@
+package nl.erwinvaneyk.core.logging;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nl.erwinvaneyk.communication.BasicMessage;
+import nl.erwinvaneyk.communication.Message;
+import nl.erwinvaneyk.core.Address;
+import nl.erwinvaneyk.core.NodeAddressImpl;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class InfluxLoggerTest {
+
+	private static InfluxLogger influx;
+
+	@Before
+	public void beforeMethod() {
+		assumeTrue(influx.isAvailable());
+	}
+
+	@BeforeClass
+	public static void setupDatabaseConnection() {
+		influx = new InfluxLogger(new Address("localhost",8086), "root", "root", "distributedrmi-test");
+	}
+
+	@AfterClass
+	public static void removeTestDatabase() {
+		influx.deleteDatabase();
+	}
+
+	@Test
+	public void testLogEmpty() {
+		Map<String, Object> args = new HashMap<>();
+		influx.log("test", args);
+	}
+
+
+	@Test
+	public void testLogWithValues() {
+		Map<String, Object> args = new HashMap<>();
+		args.put("abc", "def");
+		args.put("value", 42);
+		influx.log("test", args);
+	}
+
+	@Test
+	public void testLogMessage() {
+		Message message = new BasicMessage("test", new NodeAddressImpl("TEST-NODE", 1, new Address("127.0.0.1", 1818)));
+		message.put("test-field", 42);
+		influx.log(message);
+	}
+}

--- a/src/test/java/nl/erwinvaneyk/core/logging/LogNodeTest.java
+++ b/src/test/java/nl/erwinvaneyk/core/logging/LogNodeTest.java
@@ -1,4 +1,4 @@
-package nl.erwinvaneyk.core.LogNode;
+package nl.erwinvaneyk.core.logging;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
@@ -9,8 +9,6 @@ import nl.erwinvaneyk.communication.ConnectorImpl;
 import nl.erwinvaneyk.communication.Message;
 import nl.erwinvaneyk.core.ClusterFactory;
 import nl.erwinvaneyk.core.Node;
-import nl.erwinvaneyk.core.logging.LogMessage;
-import nl.erwinvaneyk.core.logging.LogNode;
 import org.junit.Test;
 
 public class LogNodeTest {


### PR DESCRIPTION
This adds performance logging to the project. This type logging differs from the other logging functionality, as it will be just local logging. Logs will not be send over the network to log-nodes. Instead the node will log them itself. This is useful for situations wherein the node needs to log lots of data-points. Otherwise all these log-messages would just clutter the network. 

This type of logging (like the other one) is very fault-tolerant. If it cannot connect to the database for whatever reason, it will just continue on without logging. 

- As the default database for the local logging, InfluxDB is used. See README for installation instructions
- There is currently one situation in which logs are collected, namely in the MessageDistributor.
- Changed the timestamp from Date to long, because it makes more sense. :+)