### PR TITLE
Link to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # distributedrmi
 
-![status](https://travis-ci.org/erwinvaneyk/distributedrmi.svg)
+[![Build Status](https://travis-ci.org/erwinvaneyk/distributedrmi.svg)](https://travis-ci.org/erwinvaneyk/distributedrmi)
 
 Installation:
 To use it in your project add the following to your `pom.xml`:


### PR DESCRIPTION
Image now linking to the actual Travis CI page, instead of just the status-image.