### PR TITLE
Fixed misleading logs + empty LogMessages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>nl.erwinvaneyk</groupId>
 	<artifactId>distributedrmi</artifactId>
-	<version>1.2.7</version>
+	<version>1.2.8</version>
 	<packaging>jar</packaging>
 
 	<name>distributedrmi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>nl.erwinvaneyk</groupId>
 	<artifactId>distributedrmi</artifactId>
-	<version>1.2.8</version>
+	<version>1.2.9</version>
 	<packaging>jar</packaging>
 
 	<name>distributedrmi</name>

--- a/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
+++ b/src/main/java/nl/erwinvaneyk/communication/ConnectorImpl.java
@@ -48,10 +48,12 @@ public class ConnectorImpl implements Connector {
         Set<NodeAddress> nodes = me.getConnectedNodes().stream()
                     .filter(n -> n.getIdentifier().matches(regex))
                     .collect(toSet());
-		log.debug("Sending message {} to filtered nodes: {} by using filter {}", message, nodes, identifierFilter);
 
-        if(me.getAddress().getIdentifier().matches(regex))
+        if(me.getAddress().getIdentifier().matches(regex)) {
             nodes.add(me.getAddress());
+        }
+
+        log.debug("Sending message {} to filtered nodes: {} by using filter {}", message, nodes, identifierFilter);
 
         return broadcast(message, nodes);
     }

--- a/src/main/java/nl/erwinvaneyk/core/logging/PrintLogger.java
+++ b/src/main/java/nl/erwinvaneyk/core/logging/PrintLogger.java
@@ -6,6 +6,13 @@ public class PrintLogger implements Logger {
 
 	@Override
 	public void log(Message message) {
+		if(message instanceof LogMessage) {
+			LogMessage logMessage = (LogMessage) message;
+			if(logMessage.getLog() == null || "null".equals(logMessage.getLog())) {
+				return;
+			}
+		}
+
 		System.out.println(message.toString());
 	}
 


### PR DESCRIPTION
- Logs contain your own address as well at broadcasting with a filter.
- Empty `LogMessages` are being ignored by the `PrintLogger` too.
- Bump to version `1.2.9`
